### PR TITLE
[feature] replace scope with subsystem and manage capability with permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 The RBACv2 Generator is a tool designed to create RBACv2 cluster roles (manage/use) for modules based on their CRDs.
 
 This tool reads and analyzes CRDs, and if they pass filters, it generates cluster roles in the ```templates/rbacv2``` directory. 
-The type of generated role (use or manage) is determined by the resource’s scope:
+The type of generated role (use or manage) is determined by the resource’s subsystem:
 
 • *Namespaced resources*: Use roles are generated.
 
 • *Cluster-wide resources*: Manage roles are generated.
 
 ### Use
-This following command to generate roles and docs:
+Use the following command to generate roles and docs:
 
 ```rbacgen generate . docs.yaml``` 
 
@@ -23,11 +23,11 @@ This file contains the information required by the generator to create the roles
 ### Spec examples
 
 Below is an example for the ```deckhouse``` module. 
-It includes the module name, module namespace, scopes, and the path to the CRDs:
+It includes the module name, module namespace, subsystems, and the path to the CRDs:
 ```yaml
 module: deckhouse
 namespace: d8-system
-scopes:
+subsystems:
   - deckhouse
 crds:
   - deckhouse-controller/crds/*.yaml
@@ -37,7 +37,7 @@ Some modules do not have a namespace. For these modules, you need to explicitly 
 ```yaml
 module: priority-class
 namespace: none
-scopes:
+subsystems:
   - kubernetes
 ```
 
@@ -49,7 +49,7 @@ the tool assumes the namespace is ```d8-MODULE_NAME```:
 
 ```yaml
 module: ceph-csi
-scopes:
+subsystems:
   - storage
   - infrastructure
 crds:
@@ -61,7 +61,7 @@ However, if a module provides additional resources in other groups,
 you can include them by specifying them in the configuration:
 ```yaml
 module: operator-trivy
-scopes:
+subsystems:
   - security
 crds:
   - ee/modules/500-operator-trivy/crds/native/*.yaml

--- a/example.yaml
+++ b/example.yaml
@@ -1,7 +1,7 @@
 module: MODULE_NAME
-scopes:
-  - SCOPE
-  - SCOPE
+subsystems:
+  - SUBSYSTEM
+  - SUBSYSTEM
 crds:
   - path/to/crds/*.yaml
 allowedResources:

--- a/internal/engine/main.go
+++ b/internal/engine/main.go
@@ -18,7 +18,7 @@ const RolesBasePath = "templates/rbacv2"
 type Spec struct {
 	Module             string     `yaml:"module"`
 	Namespace          string     `json:"namespace"`
-	Scopes             []string   `yaml:"scopes"`
+	Subsystems         []string   `yaml:"subsystems"`
 	CRDs               []string   `yaml:"crds"`
 	AllowedResources   []Resource `yaml:"allowedResources"`
 	ForbiddenResources []string   `yaml:"forbiddenResources"`
@@ -35,8 +35,8 @@ func WalkAndRender(ctx context.Context, dir, docsPath string) error {
 		return err
 	}
 	docs := doc{
-		Scopes:  make(map[string]*scopeDoc),
-		Modules: make(map[string]*moduleDoc),
+		Subsystems: make(map[string]*subsystemDoc),
+		Modules:    make(map[string]*moduleDoc),
 	}
 	for _, spec := range specs {
 		moduleDocs, err := renderBySpec(ctx, spec)
@@ -44,7 +44,7 @@ func WalkAndRender(ctx context.Context, dir, docsPath string) error {
 			return err
 		}
 		docs.Modules[spec.Module] = moduleDocs
-		docs.addScopeDoc(spec.Module, spec.Scopes)
+		docs.addSubsystemDoc(spec.Module, spec.Subsystems)
 	}
 	return docs.writeTo(docsPath)
 }
@@ -105,7 +105,7 @@ func renderBySpec(ctx context.Context, spec *Spec) (*moduleDoc, error) {
 			return nil, err
 		}
 	}
-	return buildModuleDoc(spec.Namespace, spec.Scopes, manage, use), err
+	return buildModuleDoc(spec.Namespace, spec.Subsystems, manage, use), err
 }
 
 func parseAndBuildRoles(ctx context.Context, spec *Spec) ([]*rbacv1.ClusterRole, []*rbacv1.ClusterRole, error) {
@@ -138,6 +138,6 @@ func parseAndBuildRoles(ctx context.Context, spec *Spec) ([]*rbacv1.ClusterRole,
 	if err != nil {
 		return nil, nil, err
 	}
-	manage, use := buildRoles(spec.Module, spec.Namespace, spec.Scopes, parsed.ClusterCRDs, parsed.NamespacedCRDs)
+	manage, use := buildRoles(spec.Module, spec.Namespace, spec.Subsystems, parsed.ClusterCRDs, parsed.NamespacedCRDs)
 	return manage, use, nil
 }


### PR DESCRIPTION
Description
It replaces manage capability with manage permission and replace scope with subsystem.

Why do we need it, and what problem does it solve?
We need to more clearly separate the use and manage roles.

Deckhouse PR: https://github.com/deckhouse/deckhouse/pull/10810